### PR TITLE
Introduce case-insensitive like search

### DIFF
--- a/src/SearchesRelations.php
+++ b/src/SearchesRelations.php
@@ -90,7 +90,8 @@ trait SearchesRelations
             $operator = static::operator($query);
 
             foreach ($columns as $column) {
-                $query->orWhere($model->qualifyColumn($column), $operator, '%'.$search.'%');
+                $column = $model->qualifyColumn($column);
+                $query->orWhere(\DB::raw("LOWER($column)"), $operator, '%' . strtolower($search) . '%');
             }
         };
     }


### PR DESCRIPTION
Changing the collation of MySQL is no longer a solution for searching insensitive cases with LIKE. The search field and search query must therefore be standardised in the casing.