### PR TITLE
Cleanup

### DIFF
--- a/src/RelationSearchQuery.php
+++ b/src/RelationSearchQuery.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Titasgailius\SearchRelations;
+
+use Illuminate\Database\Eloquent\Builder;
+
+class RelationSearchQuery
+{
+    /**
+     * Searchable relations.
+     *
+     * @var array
+     */
+    protected $relations;
+
+    /**
+     * Instantiate a new search query instance.
+     *
+     * @param array $relations
+     */
+    public function __construct(array $relations)
+    {
+        $this->relations = $relations;
+    }
+
+    /**
+     * Apply search query.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder $query
+     * @param  string $search
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function apply(Builder $query, $search): Builder
+    {
+        foreach ($this->relations as $relation => $columns) {
+            $query->orWhereHas($relation, function ($query) use ($columns, $search) {
+                (new SearchQuery($columns))->apply($query, $search);
+            });
+        }
+
+        return $query;
+    }
+}

--- a/src/SearchQuery.php
+++ b/src/SearchQuery.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Titasgailius\SearchRelations;
+
+use Illuminate\Database\Eloquent\Builder;
+
+class SearchQuery
+{
+    /**
+     * Searchable columns.
+     *
+     * @var array
+     */
+    protected $columns;
+
+    /**
+     * Instantiate a new search query.
+     *
+     * @param array $columns
+     */
+    public function __construct(array $columns)
+    {
+        $this->columns = $columns;
+    }
+
+    /**
+     * Apply search query.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder $query
+     * @param  string $search
+     * @return Builder
+     */
+    public function apply(Builder $query, $search): Builder
+    {
+        return $query->where(function ($query) use ($search) {
+            return $this->applySearchQuery($query, $search);
+        });
+    }
+
+    /**
+     * Apply search query.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder $query
+     * @param  string $search
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    protected function applySearchQuery(Builder $query, $search): Builder
+    {
+        $model = $query->getModel();
+        $operator = $this->operator($query);
+
+        foreach ($this->columns as $column) {
+            $query->orWhere($model->qualifyColumn($column), $operator, '%'.$search.'%');
+        }
+
+        return $query;
+    }
+
+    /**
+     * Get the like operator for the given query.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return string
+     */
+    protected static function operator(Builder $query): string
+    {
+        if ($query->getModel()->getConnection()->getDriverName() === 'pgsql') {
+            return 'ILIKE';
+        }
+
+        return 'LIKE';
+    }
+}

--- a/src/SearchesRelations.php
+++ b/src/SearchesRelations.php
@@ -2,7 +2,6 @@
 
 namespace Titasgailius\SearchRelations;
 
-use Closure;
 use Illuminate\Database\Eloquent\Builder;
 
 trait SearchesRelations
@@ -43,9 +42,6 @@ trait SearchesRelations
             return static::$globalSearchRelations;
         }
 
-        // This is a deprecated property. To turn off the global search, instead of setting
-        // the "$searchRelationsGlobally" property to false, it is recommended to set the
-        // "$globalSearchRelations" property to an empty array.
         if (! (static::$searchRelationsGlobally ?? true)) {
             return [];
         }


### PR DESCRIPTION
This PR cleans up the codebase by extracting logic related to applying the search query to separate classes.

## Breaking Changes 

I'm not aware of any breaking changes as only the `protected` methods have been changed.

## New classes

• `RelationSearchQuery`- this class accepts searchable relationship rules and is able to `apply` the appropriate conditions for the given query.
• `SearchQuery`- this class accepts an array of the searchable columns and is able to `apply` the appropriate conditions for the given query.
