### PR TITLE
Nova 5 Compatibility: Replace Concrete Builder with Contract Interface

### DIFF
--- a/src/Contracts/Search.php
+++ b/src/Contracts/Search.php
@@ -2,17 +2,17 @@
 
 namespace Titasgailius\SearchRelations\Contracts;
 
-use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Contracts\Database\Eloquent\Builder;
 
 interface Search
 {
     /**
      * Apply search for the given relation.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  \Illuminate\Contracts\Database\Eloquent\Builder  $query
      * @param  string  $relation
      * @param  string  $search
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return \Illuminate\Contracts\Database\Eloquent\Builder
      */
     public function apply(Builder $query, string $relation, string $search): Builder;
 }

--- a/src/Searches/ColumnSearch.php
+++ b/src/Searches/ColumnSearch.php
@@ -2,7 +2,7 @@
 
 namespace Titasgailius\SearchRelations\Searches;
 
-use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Contracts\Database\Eloquent\Builder;
 use Titasgailius\SearchRelations\Contracts\Search;
 
 class ColumnSearch implements Search
@@ -27,10 +27,10 @@ class ColumnSearch implements Search
     /**
      * Apply search for the given relation.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  Illuminate\Contracts\Database\Eloquent\Builder  $query
      * @param  string  $relation
      * @param  string  $search
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return Illuminate\Contracts\Database\Eloquent\Builder
      */
     public function apply(Builder $query, string $relation, string $search): Builder
     {
@@ -42,9 +42,9 @@ class ColumnSearch implements Search
     /**
      * Apply search query.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder $query
+     * @param  Illuminate\Contracts\Database\Eloquent\Builder $query
      * @param  string $search
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return Illuminate\Contracts\Database\Eloquent\Builder
      */
     protected function applySearchQuery(Builder $query, string $search): Builder
     {
@@ -61,7 +61,7 @@ class ColumnSearch implements Search
     /**
      * Get the like operator for the given query.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  Illuminate\Contracts\Database\Eloquent\Builder  $query
      * @return string
      */
     protected function operator(Builder $query): string

--- a/src/Searches/RelationSearch.php
+++ b/src/Searches/RelationSearch.php
@@ -2,7 +2,7 @@
 
 namespace Titasgailius\SearchRelations\Searches;
 
-use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Contracts\Database\Eloquent\Builder;
 use Titasgailius\SearchRelations\Contracts\Search;
 use Illuminate\Database\Eloquent\RelationNotFoundException;
 
@@ -28,10 +28,10 @@ class RelationSearch implements Search
     /**
      * Apply search for the given relation.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  \Illuminate\Contracts\Database\Eloquent\Builder  $query
      * @param  string  $relation
      * @param  string  $search
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return \Illuminate\Contracts\Database\Eloquent\Builder
      */
     public function apply(Builder $query, string $relation, string $search): Builder
     {

--- a/src/SearchesRelations.php
+++ b/src/SearchesRelations.php
@@ -3,7 +3,7 @@
 namespace Titasgailius\SearchRelations;
 
 use InvalidArgumentException;
-use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Contracts\Database\Eloquent\Builder;
 use Titasgailius\SearchRelations\Contracts\Search;
 use Titasgailius\SearchRelations\Searches\RelationSearch;
 
@@ -73,11 +73,11 @@ trait SearchesRelations
     /**
      * Apply the search query to the query.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  Illuminate\Contracts\Database\Eloquent\Builder  $query
      * @param  string  $search
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return Illuminate\Contracts\Database\Eloquent\Builder
      */
-    protected static function applySearch($query, $search): Builder
+    protected static function applySearch(Builder $query, string $search): Builder
     {
         return $query->where(function ($query) use ($search) {
             parent::applySearch($query, $search);
@@ -88,9 +88,9 @@ trait SearchesRelations
     /**
      * Apply the relationship search query to the given query.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  Illuminate\Contracts\Database\Eloquent\Builder  $query
      * @param  string  $search
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return Illuminate\Contracts\Database\Eloquent\Builder
      */
     protected static function applyRelationSearch(Builder $query, string $search): Builder
     {


### PR DESCRIPTION
This Pull Request implements two critical changes to ensure full compatibility with **Laravel Nova 5** and refers to **#46** (the main tracking issue):

1.  **Adding Input Type Hints:**
    * In Nova 5, the `applySearch` method now requires its input arguments (such as `$query` and `$search`) to be explicitly type-hinted. This is necessary to align with structural changes in Nova.

2.  **Replacing Concrete Builder with Contract Interface:**
    * The type hint for the Eloquent Builder has been switched from the concrete class to the contract interface, which is now required by Nova 5 for proper dependency handling:
        * **Replaced:** `Illuminate\Database\Eloquent\Builder` (Concrete Class)
        * **With:** `Illuminate\Contracts\Database\Eloquent\Builder` (Contract Interface)

With these changes, the `applySearch` method signature is updated for Nova 5 compliance:
`protected static function applySearch(\Illuminate\Contracts\Database\Eloquent\Builder $query, string $search): \Illuminate\Contracts\Database\Eloquent\Builder`

---

#### 🔗 Related Context

This PR completes the necessary method signature updates for Nova 5 support.

* This work builds upon the return type fix introduced in **[PR #44](https://github.com/TitasGailius/nova-search-relations/pull/44)**, by now addressing the required input types and contract interface usage.

The package should be fully functional and compatible with Laravel Nova 5 installations after this merge.